### PR TITLE
Use absolute path for temp directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Use absolute path for temp directory.
+
 # 0.1.1
 
 * Do not put "object" into directory name

--- a/index.js
+++ b/index.js
@@ -41,14 +41,14 @@ function findBaseDir () {
   if (baseDir == null) {
     try {
       if (fs.statSync('tmp').isDirectory()) {
-        baseDir = 'tmp'
+        baseDir = fs.realpathSync('tmp')
       }
     } catch (err) {
       if (err.code !== 'ENOENT') throw err
       // We could try other directories, but for now we just create ./tmp if
       // it doesn't exist
       fs.mkdirSync('tmp')
-      baseDir = 'tmp'
+      baseDir = fs.realpathSync('tmp')
     }
   }
 }


### PR DESCRIPTION
This changes to store the absolute path to the tmp dir instead of the relative path.

---

Before this change, the following would fail:

``` javascript
var fs = require('fs') var quickTemp = require('quick-temp')

var somePathObj = {}
fs.mkdirSync('somePath')
process.chdir('somePath') 
quickTemp.makeOrRemake(somePathObj, 'tmpDestDir')

var someOtherPathObj = {}
fs.mkdirSync('someOtherPath') 
process.chdir('someOtherPath')
quickTemp.makeOrRemake(someOtherPathObj, 'tmpDestDir')
```

This fails because the local `baseDir` var is set/cached with a value that
references `tmp`, but once `process.cwd` changes we don't check for the
existence of `tmp/` again.
