### PR TITLE
Use os.tmpdir() as the baseDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var os = require('os')
 var fs = require('fs')
 var path = require('path')
 var mktemp = require('mktemp')
@@ -35,7 +36,7 @@ function makeTmpDir(obj, prop) {
   return mktemp.createDirSync(path.join(baseDir, tmpDirName))
 }
 
-var baseDir
+var baseDir = os.tmpdir()
 
 function findBaseDir () {
   if (baseDir == null) {


### PR DESCRIPTION
Read issue #2 and thought this was a better solution.
Why not just use the operating system's directory for temp files?