### PR TITLE
pin makeOrRemake to the same tmpDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var underscoreString = require('underscore.string')
 exports.makeOrRemake = makeOrRemake
 function makeOrRemake(obj, prop, className) {
   if (obj[prop] != null) {
-    remove(obj, prop)
+    remake(obj, prop)
+    return obj[prop]
   }
   return obj[prop] = makeTmpDir(obj, prop, className)
 }
@@ -18,6 +19,15 @@ function makeOrReuse(obj, prop, className) {
     return obj[prop]
   }
   return obj[prop] = makeTmpDir(obj, prop, className)
+}
+
+exports.remake = remake
+function remake(obj, prop) {
+  var fullpath = obj[prop];
+  if (fullpath != null) {
+    rimraf.sync(fullpath);
+    fs.mkdirSync(fullpath);
+  }
 }
 
 exports.remove = remove


### PR DESCRIPTION
makeOrRemake could reuse its existing directory, merely cleaning it first.

This makes [broccoli-writer maintain a tmpdir](https://github.com/broccolijs/broccoli-writer/blob/master/index.js#L10), preventing un-needed downstream instability.

This should continue to be backwards compatible, as the only invariant of remake was to provide a clean tmp dir, no reason we can't reuse the existing

