### PR TITLE
Update rimraf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/joliss/node-quick-temp"
   },
   "dependencies": {
-    "rimraf": "~2.2.6",
+    "rimraf": "~2.5.4",
     "mktemp": "~0.3.4",
     "underscore.string": "~2.3.3"
   }


### PR DESCRIPTION
I have to work on a Windows machine, and I'm using ember-cli which has this module as a dependency. This update does not seem to break anything, but there are no tests.

Windows support issue: https://github.com/isaacs/rimraf/issues/72

Thanks!
