### PR TITLE
Add `buildTmpPath` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,20 @@ quickTemp.remove(this, 'tmpDestDir');
 
 This will also assign `this.tmpDestDir = null`. If `this.tmpDestDir` is
 already null or undefined, it will be a no-op.
+
+### Building a temporary directory path
+
+To generate a temporary directory path (but not create it) and assign its
+path to `this.someThing`, call:
+
+```js
+quickTemp.buildTmpPath(this, 'someThing')
+```
+
+An optional third argument lets you override the class-name component of the
+temporary directory name:
+
+```js
+quickTemp.buildTmpPath(this, 'tmpDestDir', 'TreeMerger');
+quickTemp.buildTmpPath(this, 'tmpDestDir', this.constructor.name); // default
+```

--- a/index.js
+++ b/index.js
@@ -4,6 +4,14 @@ var mktemp = require('mktemp')
 var rimraf = require('rimraf')
 var underscoreString = require('underscore.string')
 
+exports.buildTmpPath = buildTmpPath
+function buildTmpPath(obj, prop, className) {
+  if (className == null) className = obj.constructor && obj.constructor.name
+
+  var tmpDirName = prettyTmpDirName(className, prop)
+  return obj[prop] = path.join(findBaseDir(), tmpDirName)
+}
+
 exports.makeOrRemake = makeOrRemake
 function makeOrRemake(obj, prop, className) {
   if (obj[prop] != null) {
@@ -40,9 +48,8 @@ function remove(obj, prop) {
 
 
 function makeTmpDir(obj, prop, className) {
-  if (className == null) className = obj.constructor && obj.constructor.name
-  var tmpDirName = prettyTmpDirName(className, prop)
-  return mktemp.createDirSync(path.join(findBaseDir(), tmpDirName))
+  var tmpDirPath = buildTmpPath(obj, prop, className)
+  return mktemp.createDirSync(tmpDirPath)
 }
 
 function currentTmp() {


### PR DESCRIPTION
Allows generating the path to be separated from creating the directory.

There are a number of use cases where a path will likely not need to be created eagerly (i.e. broccoli-funnel in most cases has to remove its output path only to symlink it 
from an input path).