### PR TITLE
Enable execution in a particular context directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,20 +5,20 @@ var rimraf = require('rimraf')
 var underscoreString = require('underscore.string')
 
 exports.makeOrRemake = makeOrRemake
-function makeOrRemake(obj, prop, className) {
+function makeOrRemake(obj, prop, className, cwd) {
   if (obj[prop] != null) {
     remake(obj, prop)
     return obj[prop]
   }
-  return obj[prop] = makeTmpDir(obj, prop, className)
+  return obj[prop] = makeTmpDir(obj, prop, className, cwd)
 }
 
 exports.makeOrReuse = makeOrReuse
-function makeOrReuse(obj, prop, className) {
+function makeOrReuse(obj, prop, className, cwd) {
   if (obj[prop] != null) {
     return obj[prop]
   }
-  return obj[prop] = makeTmpDir(obj, prop, className)
+  return obj[prop] = makeTmpDir(obj, prop, className, cwd)
 }
 
 exports.remake = remake
@@ -39,18 +39,19 @@ function remove(obj, prop) {
 }
 
 
-function makeTmpDir(obj, prop, className) {
+function makeTmpDir(obj, prop, className, cwd) {
   if (className == null) className = obj.constructor && obj.constructor.name
   var tmpDirName = prettyTmpDirName(className, prop)
-  return mktemp.createDirSync(path.join(findBaseDir(), tmpDirName))
+  return mktemp.createDirSync(path.join(findBaseDir(cwd), tmpDirName))
 }
 
-function currentTmp() {
-  return path.join(process.cwd(), 'tmp')
+function currentTmp(cwd) {
+  var dir = cwd || process.cwd()
+  return path.join(dir, 'tmp')
 }
 
-function findBaseDir () {
-  var tmp = currentTmp();
+function findBaseDir (cwd) {
+  var tmp = currentTmp(cwd);
   try {
     if (fs.statSync(tmp).isDirectory()) {
       return tmp;


### PR DESCRIPTION
We use this library inside of Ember CLI's testing story, but we need a way to be able to execute in a particular directory. [The current pattern for doing that looks like this](https://github.com/ember-cli/ember-cli/blob/f8be5b26ca5821d5b900d5b1018789bbd8e44002/tests/helpers/package-cache.js#L344-L346):
```javascript
process.chdir(...);
quickTemp.makeOrRemake(...);
process.chdir(...)
```

That's far less than ideal. This PR enables this invocation pattern:
`quickTemp.makeOrRemake({}, 'property', 'className', directory);`

Thoughts?